### PR TITLE
Update for 2019

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 .settings
 target/
 /bin/
+
+# IDEA IntelliJ files
+.idea/
+*.iml
+

--- a/pom.xml
+++ b/pom.xml
@@ -13,13 +13,13 @@
   </description>
   
   <properties>
-      <confluent.version>3.1.0-SNAPSHOT</confluent.version>
-      <kafka.version>0.10.1.0-SNAPSHOT</kafka.version>
+      <confluent.version>3.1.0</confluent.version>
+      <kafka.version>0.10.1.0</kafka.version>
       <junit.version>4.12</junit.version>
       <hadoop.version>2.6.1</hadoop.version>
       <joda.version>2.9.4</joda.version>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+      <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
   </properties>
   
   <repositories>

--- a/src/main/java/com/jametson/monaka/partitioner/DailyPartition.java
+++ b/src/main/java/com/jametson/monaka/partitioner/DailyPartition.java
@@ -1,45 +1,44 @@
 package com.jametson.monaka.partitioner;
 
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import org.apache.kafka.common.config.ConfigException;
+import org.joda.time.DateTimeZone;
+
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.kafka.common.config.ConfigException;
-import org.joda.time.DateTimeZone;
+public class DailyPartition extends TimeBasedPartition {
+    private static long partitionDurationMs = TimeUnit.HOURS.toMillis(24);
+    private static String pathFormat = "YYYY/MM/dd/";
 
-import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+    @Override
+    public void configure(Map<String, Object> config) {
+        String localeString = (String) config.get(HdfsSinkConnectorConfig.LOCALE_CONFIG);
+        if (localeString.equals("")) {
+            throw new ConfigException(HdfsSinkConnectorConfig.LOCALE_CONFIG, localeString, "Locale cannot be empty.");
+        }
 
-public class DailyPartition extends TimeBasedPartition{
-	private static long partitionDurationMs = TimeUnit.HOURS.toMillis(24);
-	private static String pathFormat = "YYYY/MM/dd/";
+        String timeZoneString = (String) config.get(HdfsSinkConnectorConfig.TIMEZONE_CONFIG);
+        if (timeZoneString.equals("")) {
+            throw new ConfigException(HdfsSinkConnectorConfig.TIMEZONE_CONFIG, timeZoneString,
+                    "Timezone cannot be empty.");
+        }
 
-	@Override
-	public void configure(Map<String, Object> config) {
-		String localeString = (String) config.get(HdfsSinkConnectorConfig.LOCALE_CONFIG);
-		if (localeString.equals("")) {
-			throw new ConfigException(HdfsSinkConnectorConfig.LOCALE_CONFIG, localeString, "Locale cannot be empty.");
-		}
-		
-		String timeZoneString = (String) config.get(HdfsSinkConnectorConfig.TIMEZONE_CONFIG);
-		if (timeZoneString.equals("")) {
-			throw new ConfigException(HdfsSinkConnectorConfig.TIMEZONE_CONFIG, timeZoneString,
-					"Timezone cannot be empty.");
-		}
-		
-		String hiveIntString = (String) config.get(HdfsSinkConnectorConfig.HIVE_INTEGRATION_CONFIG);
-		boolean hiveIntegration = hiveIntString != null && hiveIntString.toLowerCase().equals("true");
+        String hiveIntString = (String) config.get(HdfsSinkConnectorConfig.HIVE_INTEGRATION_CONFIG);
+        boolean hiveIntegration = hiveIntString != null && hiveIntString.toLowerCase().equals("true");
 
-		boolean includeDateName = System.getProperty("partition.include.date.name", "false").toLowerCase().equals("true");
-		if (includeDateName) {
-			pathFormat = "'year'=YYYY/'month'=MM/'day'=dd/";
-		}
-		
-		Locale locale = new Locale(localeString);
-		DateTimeZone timeZone = DateTimeZone.forID(timeZoneString);
-		init(partitionDurationMs, pathFormat, locale, timeZone, hiveIntegration);
-	}
+        boolean includeDateName = System.getProperty("partition.include.date.name", "false").toLowerCase().equals("true");
+        if (includeDateName) {
+            pathFormat = "'year'=YYYY/'month'=MM/'day'=dd/";
+        }
 
-	public String getPathFormat() {
-		return pathFormat;
-	}
+        Locale locale = new Locale(localeString);
+        DateTimeZone timeZone = DateTimeZone.forID(timeZoneString);
+        init(partitionDurationMs, pathFormat, locale, timeZone, hiveIntegration);
+    }
+
+    public String getPathFormat() {
+        return pathFormat;
+    }
 }

--- a/src/main/java/com/jametson/monaka/partitioner/FieldPartition.java
+++ b/src/main/java/com/jametson/monaka/partitioner/FieldPartition.java
@@ -1,74 +1,73 @@
 package com.jametson.monaka.partitioner;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import io.confluent.connect.hdfs.errors.PartitionException;
+import io.confluent.connect.hdfs.partitioner.FieldPartitioner;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
-import io.confluent.connect.hdfs.errors.PartitionException;
-import io.confluent.connect.hdfs.partitioner.FieldPartitioner;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
-public class FieldPartition extends FieldPartitioner{
-	private static final Logger log = LoggerFactory.getLogger(FieldPartitioner.class);
-	private static String fieldName;
-	private List<FieldSchema> partitionFields = new ArrayList<>();
-	
-	@Override
-	public void configure(Map<String, Object> config) {
-		fieldName = (String) config.get(HdfsSinkConnectorConfig.PARTITION_FIELD_NAME_CONFIG);
-		partitionFields.add(new FieldSchema(fieldName, TypeInfoFactory.stringTypeInfo.toString(), ""));
-	}
-	
-	@Override
-	public String encodePartition(SinkRecord sinkRecord) {
-		Object value = sinkRecord.value();
-		Schema valueSchema = sinkRecord.valueSchema();
-		
-		boolean includeFieldName = System.getProperty("partition.include.field.name", "false").toLowerCase().equals("true");
-		
-		if (value instanceof Struct) {
-			Struct struct = (Struct) value;
-			Object partitionKey = struct.get(fieldName);
-			Type type = valueSchema.field(fieldName).schema().type();
-			
-			String pathFormat = "";
-			if (includeFieldName) {
-				pathFormat = fieldName + "=";
-			}
-			
-			switch (type) {
-			case INT8:
-			case INT16:
-			case INT32:
-			case INT64:
-				Number record = (Number) partitionKey;
-				return pathFormat + record.toString();
-			case STRING:
-				return pathFormat + (String) partitionKey;
-			case BOOLEAN:
-				boolean booleanRecord = (boolean) partitionKey;
-				return pathFormat + Boolean.toString(booleanRecord);
-			default:
-				log.error("Type {} is not supported as a partition key.", type.getName());
-				throw new PartitionException("Error encoding partition.");
-			}
-		} else {
-			log.error("Value is not Struct type.");
-			throw new PartitionException("Error encoding partition.");
-		}
-	}
-	
-	@Override
-	public List<FieldSchema> partitionFields() {
-		return partitionFields;
-	}
+public class FieldPartition extends FieldPartitioner {
+    private static final Logger log = LoggerFactory.getLogger(FieldPartitioner.class);
+    private static String fieldName;
+    private List<FieldSchema> partitionFields = new ArrayList<>();
+
+    @Override
+    public void configure(Map<String, Object> config) {
+        fieldName = (String) config.get(HdfsSinkConnectorConfig.PARTITION_FIELD_NAME_CONFIG);
+        partitionFields.add(new FieldSchema(fieldName, TypeInfoFactory.stringTypeInfo.toString(), ""));
+    }
+
+    @Override
+    public String encodePartition(SinkRecord sinkRecord) {
+        Object value = sinkRecord.value();
+        Schema valueSchema = sinkRecord.valueSchema();
+
+        boolean includeFieldName = System.getProperty("partition.include.field.name", "false").toLowerCase().equals("true");
+
+        if (value instanceof Struct) {
+            Struct struct = (Struct) value;
+            Object partitionKey = struct.get(fieldName);
+            Type type = valueSchema.field(fieldName).schema().type();
+
+            String pathFormat = "";
+            if (includeFieldName) {
+                pathFormat = fieldName + "=";
+            }
+
+            switch (type) {
+                case INT8:
+                case INT16:
+                case INT32:
+                case INT64:
+                    Number record = (Number) partitionKey;
+                    return pathFormat + record.toString();
+                case STRING:
+                    return pathFormat + (String) partitionKey;
+                case BOOLEAN:
+                    boolean booleanRecord = (boolean) partitionKey;
+                    return pathFormat + Boolean.toString(booleanRecord);
+                default:
+                    log.error("Type {} is not supported as a partition key.", type.getName());
+                    throw new PartitionException("Error encoding partition.");
+            }
+        } else {
+            log.error("Value is not Struct type.");
+            throw new PartitionException("Error encoding partition.");
+        }
+    }
+
+    @Override
+    public List<FieldSchema> partitionFields() {
+        return partitionFields;
+    }
 }

--- a/src/main/java/com/jametson/monaka/partitioner/HourlyPartition.java
+++ b/src/main/java/com/jametson/monaka/partitioner/HourlyPartition.java
@@ -1,46 +1,45 @@
 package com.jametson.monaka.partitioner;
 
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import org.apache.kafka.common.config.ConfigException;
+import org.joda.time.DateTimeZone;
+
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.kafka.common.config.ConfigException;
-import org.joda.time.DateTimeZone;
+public class HourlyPartition extends TimeBasedPartition {
 
-import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+    private static long partitionDurationMs = TimeUnit.HOURS.toMillis(1);
+    private static String pathFormat = "YYYY/MM/dd/HH/";
 
-public class HourlyPartition extends TimeBasedPartition{
-	
-	private static long partitionDurationMs = TimeUnit.HOURS.toMillis(1);
-	private static String pathFormat = "YYYY/MM/dd/HH/";
-	
-	@Override
-	public void configure(Map<String, Object> config) {
-		String localeString = (String) config.get(HdfsSinkConnectorConfig.LOCALE_CONFIG);
-		if (localeString.equals("")) {
-			throw new ConfigException(HdfsSinkConnectorConfig.LOCALE_CONFIG, localeString, "Locale cannot be empty.");
-		}
-		
-		String timeZoneString = (String) config.get(HdfsSinkConnectorConfig.TIMEZONE_CONFIG);
-		if (timeZoneString.equals("")) {
-			throw new ConfigException(HdfsSinkConnectorConfig.TIMEZONE_CONFIG, timeZoneString,
-					"Timezone cannot be empty.");
-		}
-		
-		String hiveIntString = (String) config.get(HdfsSinkConnectorConfig.HIVE_INTEGRATION_CONFIG);
-		boolean hiveIntegration = hiveIntString != null && hiveIntString.toLowerCase().equals("true");
+    @Override
+    public void configure(Map<String, Object> config) {
+        String localeString = (String) config.get(HdfsSinkConnectorConfig.LOCALE_CONFIG);
+        if (localeString.equals("")) {
+            throw new ConfigException(HdfsSinkConnectorConfig.LOCALE_CONFIG, localeString, "Locale cannot be empty.");
+        }
 
-		boolean includeDateName = System.getProperty("partition.include.date.name", "false").toLowerCase().equals("true");
-		if (includeDateName) {
-			pathFormat = "'year'=YYYY/'month'=MM/'day'=dd/'hour'=HH/";
-		}
-		
-		Locale locale = new Locale(localeString);
-		DateTimeZone timeZone = DateTimeZone.forID(timeZoneString);
-		init(partitionDurationMs, pathFormat, locale, timeZone, hiveIntegration);
-	}
+        String timeZoneString = (String) config.get(HdfsSinkConnectorConfig.TIMEZONE_CONFIG);
+        if (timeZoneString.equals("")) {
+            throw new ConfigException(HdfsSinkConnectorConfig.TIMEZONE_CONFIG, timeZoneString,
+                    "Timezone cannot be empty.");
+        }
 
-	public String getPathFormat() {
-		return pathFormat;
-	}
+        String hiveIntString = (String) config.get(HdfsSinkConnectorConfig.HIVE_INTEGRATION_CONFIG);
+        boolean hiveIntegration = hiveIntString != null && hiveIntString.toLowerCase().equals("true");
+
+        boolean includeDateName = System.getProperty("partition.include.date.name", "false").toLowerCase().equals("true");
+        if (includeDateName) {
+            pathFormat = "'year'=YYYY/'month'=MM/'day'=dd/'hour'=HH/";
+        }
+
+        Locale locale = new Locale(localeString);
+        DateTimeZone timeZone = DateTimeZone.forID(timeZoneString);
+        init(partitionDurationMs, pathFormat, locale, timeZone, hiveIntegration);
+    }
+
+    public String getPathFormat() {
+        return pathFormat;
+    }
 }

--- a/src/main/java/com/jametson/monaka/partitioner/TimeBasedPartition.java
+++ b/src/main/java/com/jametson/monaka/partitioner/TimeBasedPartition.java
@@ -1,9 +1,7 @@
 package com.jametson.monaka.partitioner;
 
-import java.util.Locale;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import io.confluent.connect.hdfs.partitioner.TimeBasedPartitioner;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.kafka.common.config.ConfigException;
@@ -16,67 +14,68 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
-import io.confluent.connect.hdfs.partitioner.TimeBasedPartitioner;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class TimeBasedPartition extends TimeBasedPartitioner {
 
-	// Duration of a partition in milliseconds.
-	private long partitionDurationMs;
-	private DateTimeFormatter formatter;
-	private String timeFieldName;
-	private static String patternString = "'year'=Y{1,5}/('month'=M{1,5}/)?('day'=d{1,3}/)?('hour'=H{1,3}/)?('minute'=m{1,3}/)?";
-	private static Pattern pattern = Pattern.compile(patternString);
+    // Duration of a partition in milliseconds.
+    private long partitionDurationMs;
+    private DateTimeFormatter formatter;
+    private String timeFieldName;
+    private static String patternString = "'year'=Y{1,5}/('month'=M{1,5}/)?('day'=d{1,3}/)?('hour'=H{1,3}/)?('minute'=m{1,3}/)?";
+    private static Pattern pattern = Pattern.compile(patternString);
 
-	@Override
-	protected void init(long partitionDurationMs, String pathFormat, Locale locale, DateTimeZone timeZone,
-			boolean hiveIntegration) {
-		this.partitionDurationMs = partitionDurationMs;
-		this.formatter = getDateTimeFormatter(pathFormat, timeZone).withLocale(locale);
-		this.timeFieldName = System.getProperty("partition.time.field.name", "");
-		addToPartitionFields(pathFormat, hiveIntegration);
-	}
-	
-	private static DateTimeFormatter getDateTimeFormatter(String str, DateTimeZone timeZone) {
-		return DateTimeFormat.forPattern(str).withZone(timeZone);
-	}
+    @Override
+    protected void init(long partitionDurationMs, String pathFormat, Locale locale, DateTimeZone timeZone,
+                        boolean hiveIntegration) {
+        this.partitionDurationMs = partitionDurationMs;
+        this.formatter = getDateTimeFormatter(pathFormat, timeZone).withLocale(locale);
+        this.timeFieldName = System.getProperty("partition.time.field.name", "");
+        addToPartitionFields(pathFormat, hiveIntegration);
+    }
 
-	@Override
-	public String encodePartition(SinkRecord sinkRecord) {
-		long timestamp;
-		
-		if (timeFieldName.equals("")) {
-			timestamp = System.currentTimeMillis();
-		} else {
-			try {
-				Struct struct = (Struct) sinkRecord.value();
-				timestamp = (long) struct.get(timeFieldName);
-			} catch (ClassCastException | DataException e) {
-				throw new ConnectException(e);
-			}
-		}
+    private static DateTimeFormatter getDateTimeFormatter(String str, DateTimeZone timeZone) {
+        return DateTimeFormat.forPattern(str).withZone(timeZone);
+    }
 
-		DateTime bucket = new DateTime(getPartition(partitionDurationMs, timestamp, formatter.getZone()));
-		return bucket.toString(formatter);
-	}
-	
-	private boolean verifyDateTimeFormat(String pathFormat) {
-		Matcher m = pattern.matcher(pathFormat);
-		return m.matches();
-	}
-	
-	private void addToPartitionFields(String pathFormat, boolean hiveIntegration) {
-		if (hiveIntegration && !verifyDateTimeFormat(pathFormat)) {
-			throw new ConfigException(HdfsSinkConnectorConfig.PATH_FORMAT_CONFIG, pathFormat,
-					"Path format doesn't meet the requirements for Hive integration, "
-							+ "which require prefixing each DateTime component with its name.");
-		}
-		
-		for (String field : pathFormat.split("/")) {
-			String[] parts = field.split("=");
-			FieldSchema fieldSchema = new FieldSchema(parts[0].replace("'", ""),
-					TypeInfoFactory.stringTypeInfo.toString(), "");
-			partitionFields.add(fieldSchema);
-		}
-	}
+    @Override
+    public String encodePartition(SinkRecord sinkRecord) {
+        long timestamp;
+
+        if (timeFieldName.equals("")) {
+            timestamp = System.currentTimeMillis();
+        } else {
+            try {
+                Struct struct = (Struct) sinkRecord.value();
+                timestamp = (long) struct.get(timeFieldName);
+            } catch (ClassCastException | DataException e) {
+                throw new ConnectException(e);
+            }
+        }
+
+        DateTime bucket = new DateTime(getPartition(partitionDurationMs, timestamp, formatter.getZone()));
+        return bucket.toString(formatter);
+    }
+
+    private boolean verifyDateTimeFormat(String pathFormat) {
+        Matcher m = pattern.matcher(pathFormat);
+        return m.matches();
+    }
+
+    private void addToPartitionFields(String pathFormat, boolean hiveIntegration) {
+        if (hiveIntegration && !verifyDateTimeFormat(pathFormat)) {
+            throw new ConfigException(HdfsSinkConnectorConfig.PATH_FORMAT_CONFIG, pathFormat,
+                    "Path format doesn't meet the requirements for Hive integration, "
+                            + "which require prefixing each DateTime component with its name.");
+        }
+
+        for (String field : pathFormat.split("/")) {
+            String[] parts = field.split("=");
+            FieldSchema fieldSchema = new FieldSchema(parts[0].replace("'", ""),
+                    TypeInfoFactory.stringTypeInfo.toString(), "");
+            partitionFields.add(fieldSchema);
+        }
+    }
 }

--- a/src/test/java/com/jametson/monaka/config/HdfsSinkConnectorTestBase.java
+++ b/src/test/java/com/jametson/monaka/config/HdfsSinkConnectorTestBase.java
@@ -1,74 +1,74 @@
 package com.jametson.monaka.config;
 
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.joda.time.DateTimeZone;
 
-import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 public class HdfsSinkConnectorTestBase {
-	protected static final String TOPIC = "topic";
-	protected static final int PARTITION = 1;
-	protected static final String timeZoneString = "Asia/Jakarta";
-	protected static final DateTimeZone DATE_TIME_ZONE = DateTimeZone.forID(timeZoneString);
-	
-	protected Schema createSchemaWithTimeField() {
-		return SchemaBuilder.struct().name("record").version(2)
-				.field("timestamp", Schema.INT64_SCHEMA)
-	            .field("int", Schema.INT32_SCHEMA)
-	            .field("long", Schema.INT64_SCHEMA)
-	            .field("float", Schema.FLOAT32_SCHEMA)
-	            .field("double", Schema.FLOAT64_SCHEMA)
-	            .field("string", SchemaBuilder.string().defaultValue("abc").build())
-	            .build();
-	}
-	
-	protected Struct createRecordWithTimeField(Schema schema, long timestamp) {
-		return new Struct(schema)
-				.put("timestamp", timestamp)
-		        .put("int", 12)
-		        .put("long", 12L)
-		        .put("float", 12.2f)
-		        .put("double", 12.2)
-		        .put("string", "def");
-	}
-	
-	protected Map<String, Object> createConfigBasePartition() {
-		Map<String, Object> config = new HashMap<>();
-		config.put(HdfsSinkConnectorConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.HOURS.toMillis(1));
-		config.put(HdfsSinkConnectorConfig.PATH_FORMAT_CONFIG, "YYYY/MM/dd/HH/");
-		config.put(HdfsSinkConnectorConfig.LOCALE_CONFIG, Locale.ENGLISH.toString());
-		config.put(HdfsSinkConnectorConfig.TIMEZONE_CONFIG, DATE_TIME_ZONE.toString());
+    protected static final String TOPIC = "topic";
+    protected static final int PARTITION = 1;
+    protected static final String timeZoneString = TimeZone.getDefault().getID();
+    protected static final DateTimeZone DATE_TIME_ZONE = DateTimeZone.forID(timeZoneString);
 
-		return config;
-	}
-	
-	protected Map<String, Object> createConfig() {
-		Map<String, Object> config = new HashMap<>();
-		config.put(HdfsSinkConnectorConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.HOURS.toMillis(1));
-		config.put(HdfsSinkConnectorConfig.LOCALE_CONFIG, Locale.ENGLISH.toString());
-		config.put(HdfsSinkConnectorConfig.TIMEZONE_CONFIG, DATE_TIME_ZONE.toString());
+    protected Schema createSchemaWithTimeField() {
+        return SchemaBuilder.struct().name("record").version(2)
+                .field("timestamp", Schema.INT64_SCHEMA)
+                .field("int", Schema.INT32_SCHEMA)
+                .field("long", Schema.INT64_SCHEMA)
+                .field("float", Schema.FLOAT32_SCHEMA)
+                .field("double", Schema.FLOAT64_SCHEMA)
+                .field("string", SchemaBuilder.string().defaultValue("abc").build())
+                .build();
+    }
 
-		return config;
-	}
-	
-	protected Map<String, Object> createConfigFieldName(String fieldName) {
-		Map<String, Object> config = new HashMap<>();
-		config.put(HdfsSinkConnectorConfig.PARTITION_FIELD_NAME_CONFIG, fieldName);
+    protected Struct createRecordWithTimeField(Schema schema, long timestamp) {
+        return new Struct(schema)
+                .put("timestamp", timestamp)
+                .put("int", 12)
+                .put("long", 12L)
+                .put("float", 12.2f)
+                .put("double", 12.2)
+                .put("string", "def");
+    }
 
-		return config;
-	}
-	
-	protected SinkRecord createSinkRecord(long timestamp) {
-		Schema schema = createSchemaWithTimeField();
-		Struct record = createRecordWithTimeField(schema, timestamp);
-		return new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null, schema, record, 0L);
-	}
+    protected Map<String, Object> createConfigBasePartition() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(HdfsSinkConnectorConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.HOURS.toMillis(1));
+        config.put(HdfsSinkConnectorConfig.PATH_FORMAT_CONFIG, "YYYY/MM/dd/HH/");
+        config.put(HdfsSinkConnectorConfig.LOCALE_CONFIG, Locale.ENGLISH.toString());
+        config.put(HdfsSinkConnectorConfig.TIMEZONE_CONFIG, DATE_TIME_ZONE.toString());
+
+        return config;
+    }
+
+    protected Map<String, Object> createConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(HdfsSinkConnectorConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.HOURS.toMillis(1));
+        config.put(HdfsSinkConnectorConfig.LOCALE_CONFIG, Locale.ENGLISH.toString());
+        config.put(HdfsSinkConnectorConfig.TIMEZONE_CONFIG, DATE_TIME_ZONE.toString());
+
+        return config;
+    }
+
+    protected Map<String, Object> createConfigFieldName(String fieldName) {
+        Map<String, Object> config = new HashMap<>();
+        config.put(HdfsSinkConnectorConfig.PARTITION_FIELD_NAME_CONFIG, fieldName);
+
+        return config;
+    }
+
+    protected SinkRecord createSinkRecord(long timestamp) {
+        Schema schema = createSchemaWithTimeField();
+        Struct record = createRecordWithTimeField(schema, timestamp);
+        return new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null, schema, record, 0L);
+    }
 }

--- a/src/test/java/com/jametson/monaka/partitioner/DailyPartitionTest.java
+++ b/src/test/java/com/jametson/monaka/partitioner/DailyPartitionTest.java
@@ -1,50 +1,48 @@
 package com.jametson.monaka.partitioner;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Map;
-
+import com.jametson.monaka.config.HdfsSinkConnectorTestBase;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
-import com.jametson.monaka.config.HdfsSinkConnectorTestBase;
-import com.jametson.monaka.partitioner.DailyPartition;
+import java.util.Map;
 
-public class DailyPartitionTest extends HdfsSinkConnectorTestBase{
-	
-	@Test
-	public void testGenerateWithDateName() {
-		// set property include date name
-		System.setProperty("partition.include.date.name", "true");
-		
-		// set property time field name
-		System.setProperty("partition.time.field.name", "timestamp");
-		
-		DailyPartition partitioner = new DailyPartition();
-		Map<String, Object> config = createConfig();
-		partitioner.configure(config);
-		
-		long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
-		SinkRecord sinkRecord = createSinkRecord(timestamp);
-		String encodedPartition = partitioner.encodePartition(sinkRecord);
-		
-		assertEquals("year=2016/month=09/day=19/", encodedPartition);
-	}
-	
-	@Test
-	public void testGenerateWithoutDateName() {
-		// set property time field name
-		System.setProperty("partition.time.field.name", "timestamp");
-		
-		DailyPartition partitioner = new DailyPartition();
-		Map<String, Object> config = createConfig();
-		partitioner.configure(config);
-		
-		long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
-		SinkRecord sinkRecord = createSinkRecord(timestamp);
-		String encodedPartition = partitioner.encodePartition(sinkRecord);
-		
-		assertEquals("2016/09/19/", encodedPartition);
-	}
+import static org.junit.Assert.assertEquals;
+
+public class DailyPartitionTest extends HdfsSinkConnectorTestBase {
+
+    @Test
+    public void testGenerateWithDateName() {
+        // set property include date name
+        System.setProperty("partition.include.date.name", "true");
+
+        // set property time field name
+        System.setProperty("partition.time.field.name", "timestamp");
+
+        DailyPartition partitioner = new DailyPartition();
+        Map<String, Object> config = createConfig();
+        partitioner.configure(config);
+
+        long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
+        SinkRecord sinkRecord = createSinkRecord(timestamp);
+        String encodedPartition = partitioner.encodePartition(sinkRecord);
+
+        assertEquals("year=2016/month=09/day=19/", encodedPartition);
+    }
+
+    @Test
+    public void testGenerateWithoutDateName() {
+        // set property time field name
+        System.setProperty("partition.time.field.name", "timestamp");
+
+        DailyPartition partitioner = new DailyPartition();
+        Map<String, Object> config = createConfig();
+        partitioner.configure(config);
+
+        long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
+        SinkRecord sinkRecord = createSinkRecord(timestamp);
+        String encodedPartition = partitioner.encodePartition(sinkRecord);
+
+        assertEquals("2016/09/19/", encodedPartition);
+    }
 }

--- a/src/test/java/com/jametson/monaka/partitioner/FieldPartitionTest.java
+++ b/src/test/java/com/jametson/monaka/partitioner/FieldPartitionTest.java
@@ -1,44 +1,42 @@
 package com.jametson.monaka.partitioner;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Map;
-
+import com.jametson.monaka.config.HdfsSinkConnectorTestBase;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
-import com.jametson.monaka.config.HdfsSinkConnectorTestBase;
-import com.jametson.monaka.partitioner.FieldPartition;
+import java.util.Map;
 
-public class FieldPartitionTest extends HdfsSinkConnectorTestBase{
-	
-	@Test
-	public void testGenerateWithFieldName() {
-		// set property include date name
-		System.setProperty("partition.include.field.name", "true");
-		
-		FieldPartition partitioner = new FieldPartition();
-		Map<String, Object> config = createConfigFieldName("timestamp");
-		partitioner.configure(config);
-		
-		long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
-		SinkRecord sinkRecord = createSinkRecord(timestamp);
-		String encodedPartition = partitioner.encodePartition(sinkRecord);
-		
-		assertEquals("timestamp=" + timestamp, encodedPartition);
-	}
-	
-	@Test
-	public void testGenerateWithoutDateName() {
-		FieldPartition partitioner = new FieldPartition();
-		Map<String, Object> config = createConfigFieldName("timestamp");
-		partitioner.configure(config);
-		
-		long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
-		SinkRecord sinkRecord = createSinkRecord(timestamp);
-		String encodedPartition = partitioner.encodePartition(sinkRecord);
-		
-		assertEquals(String.valueOf(timestamp), encodedPartition);
-	}
+import static org.junit.Assert.assertEquals;
+
+public class FieldPartitionTest extends HdfsSinkConnectorTestBase {
+
+    @Test
+    public void testGenerateWithFieldName() {
+        // set property include date name
+        System.setProperty("partition.include.field.name", "true");
+
+        FieldPartition partitioner = new FieldPartition();
+        Map<String, Object> config = createConfigFieldName("timestamp");
+        partitioner.configure(config);
+
+        long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
+        SinkRecord sinkRecord = createSinkRecord(timestamp);
+        String encodedPartition = partitioner.encodePartition(sinkRecord);
+
+        assertEquals("timestamp=" + timestamp, encodedPartition);
+    }
+
+    @Test
+    public void testGenerateWithoutDateName() {
+        FieldPartition partitioner = new FieldPartition();
+        Map<String, Object> config = createConfigFieldName("timestamp");
+        partitioner.configure(config);
+
+        long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
+        SinkRecord sinkRecord = createSinkRecord(timestamp);
+        String encodedPartition = partitioner.encodePartition(sinkRecord);
+
+        assertEquals(String.valueOf(timestamp), encodedPartition);
+    }
 }

--- a/src/test/java/com/jametson/monaka/partitioner/HourlyPartitionTest.java
+++ b/src/test/java/com/jametson/monaka/partitioner/HourlyPartitionTest.java
@@ -1,50 +1,48 @@
 package com.jametson.monaka.partitioner;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Map;
-
+import com.jametson.monaka.config.HdfsSinkConnectorTestBase;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
-import com.jametson.monaka.config.HdfsSinkConnectorTestBase;
-import com.jametson.monaka.partitioner.HourlyPartition;
+import java.util.Map;
 
-public class HourlyPartitionTest extends HdfsSinkConnectorTestBase{
-	
-	@Test
-	public void testGenerateWithDateName() {
-		// set property include date name
-		System.setProperty("partition.include.date.name", "true");
-		
-		// set property time field name
-		System.setProperty("partition.time.field.name", "timestamp");
-		
-		HourlyPartition partitioner = new HourlyPartition();
-		Map<String, Object> config = createConfig();
-		partitioner.configure(config);
-		
-		long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
-		SinkRecord sinkRecord = createSinkRecord(timestamp);
-		String encodedPartition = partitioner.encodePartition(sinkRecord);
-		
-		assertEquals("year=2016/month=09/day=19/hour=16/", encodedPartition);
-	}
-	
-	@Test
-	public void testGenerateWithoutDateName() {
-		// set property time field name
-		System.setProperty("partition.time.field.name", "timestamp");
-		
-		HourlyPartition partitioner = new HourlyPartition();
-		Map<String, Object> config = createConfig();
-		partitioner.configure(config);
-		
-		long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
-		SinkRecord sinkRecord = createSinkRecord(timestamp);
-		String encodedPartition = partitioner.encodePartition(sinkRecord);
-		
-		assertEquals("2016/09/19/16/", encodedPartition);
-	}
+import static org.junit.Assert.assertEquals;
+
+public class HourlyPartitionTest extends HdfsSinkConnectorTestBase {
+
+    @Test
+    public void testGenerateWithDateName() {
+        // set property include date name
+        System.setProperty("partition.include.date.name", "true");
+
+        // set property time field name
+        System.setProperty("partition.time.field.name", "timestamp");
+
+        HourlyPartition partitioner = new HourlyPartition();
+        Map<String, Object> config = createConfig();
+        partitioner.configure(config);
+
+        long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
+        SinkRecord sinkRecord = createSinkRecord(timestamp);
+        String encodedPartition = partitioner.encodePartition(sinkRecord);
+
+        assertEquals("year=2016/month=09/day=19/hour=16/", encodedPartition);
+    }
+
+    @Test
+    public void testGenerateWithoutDateName() {
+        // set property time field name
+        System.setProperty("partition.time.field.name", "timestamp");
+
+        HourlyPartition partitioner = new HourlyPartition();
+        Map<String, Object> config = createConfig();
+        partitioner.configure(config);
+
+        long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
+        SinkRecord sinkRecord = createSinkRecord(timestamp);
+        String encodedPartition = partitioner.encodePartition(sinkRecord);
+
+        assertEquals("2016/09/19/16/", encodedPartition);
+    }
 }

--- a/src/test/java/com/jametson/monaka/partitioner/TimeBasedPartitionTest.java
+++ b/src/test/java/com/jametson/monaka/partitioner/TimeBasedPartitionTest.java
@@ -1,56 +1,50 @@
 package com.jametson.monaka.partitioner;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Map;
-
+import com.jametson.monaka.config.HdfsSinkConnectorTestBase;
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.junit.Test;
 
-import com.jametson.monaka.config.HdfsSinkConnectorTestBase;
-import com.jametson.monaka.partitioner.TimeBasedPartition;
+import java.util.Map;
 
-import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import static org.junit.Assert.assertEquals;
 
-public class TimeBasedPartitionTest extends HdfsSinkConnectorTestBase{
-	private static final String timeZoneString = "Asia/Jakarta";
-	private static final DateTimeZone DATE_TIME_ZONE = DateTimeZone.forID(timeZoneString);
-	
-	@Test
-	public void testGenerateFromTimeField() {
-		// set property time field name
-		System.setProperty("partition.time.field.name", "timestamp");
-		
-		TimeBasedPartition partitioner = new TimeBasedPartition();
-		
-		Map<String, Object> config = createConfigBasePartition();
-		partitioner.configure(config);
-		
-		long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
-		SinkRecord sinkRecord = createSinkRecord(timestamp);
-		String encodedPartition = partitioner.encodePartition(sinkRecord);
-		
-		assertEquals("2016/09/19/16/", encodedPartition);
-	}
-	
-	@Test
-	public void testGenerateWithEmptyTimeField() {
-		TimeBasedPartition partitioner = new TimeBasedPartition();
-		
-		Map<String, Object> config = createConfigBasePartition();
-		partitioner.configure(config);
-		
-		long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
-		SinkRecord sinkRecord = createSinkRecord(timestamp);
-		String encodedPartition = partitioner.encodePartition(sinkRecord);
-		
-		DateTimeFormatter fmt = DateTimeFormat.forPattern((String) config.get(HdfsSinkConnectorConfig.PATH_FORMAT_CONFIG));
-		DateTime now = new DateTime();
-		
-		assertEquals(fmt.print(now), encodedPartition);
-	}
+public class TimeBasedPartitionTest extends HdfsSinkConnectorTestBase {
+
+    @Test
+    public void testGenerateFromTimeField() {
+        // set property time field name
+        System.setProperty("partition.time.field.name", "timestamp");
+
+        TimeBasedPartition partitioner = new TimeBasedPartition();
+
+        Map<String, Object> config = createConfigBasePartition();
+        partitioner.configure(config);
+
+        long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
+        SinkRecord sinkRecord = createSinkRecord(timestamp);
+        String encodedPartition = partitioner.encodePartition(sinkRecord);
+
+        assertEquals("2016/09/19/16/", encodedPartition);
+    }
+
+    @Test
+    public void testGenerateWithEmptyTimeField() {
+        TimeBasedPartition partitioner = new TimeBasedPartition();
+
+        Map<String, Object> config = createConfigBasePartition();
+        partitioner.configure(config);
+
+        long timestamp = new DateTime(2016, 9, 19, 16, 0, 0, 0, DATE_TIME_ZONE).getMillis();
+        SinkRecord sinkRecord = createSinkRecord(timestamp);
+        String encodedPartition = partitioner.encodePartition(sinkRecord);
+
+        DateTimeFormatter fmt = DateTimeFormat.forPattern((String) config.get(HdfsSinkConnectorConfig.PATH_FORMAT_CONFIG));
+        DateTime now = new DateTime();
+
+        assertEquals(fmt.print(now), encodedPartition);
+    }
 }


### PR DESCRIPTION
- Use Default TimeZone in unit tests (otherwise they fail outside "Asia/Jakarta")
- Remove dependency on SNAPSHOT confluent libs (Confluent only use them for development and are not public)
- Reformat&Optimize Imports